### PR TITLE
Fixing FTDI USB rule. Readding iobc_toolchain to PATH

### DIFF
--- a/base/bin/kubos-usb.rules
+++ b/base/bin/kubos-usb.rules
@@ -1,5 +1,5 @@
 # Rule for FTDI USB connections (ex. iOBC and STM32 UART connections)
-SUBSYSTEMS=="usb", KERNEL=="ttyUSB*", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", SYMLINK+="FTDI"
+SUBSYSTEMS=="usb", KERNEL=="ttyUSB*", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", GROUP="dialout", SYMLINK+="FTDI"
 
 # Rules for STM USB device (used for device firmware updates)
 ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", MODE="666", GROUP="plugdev"

--- a/base/script/privileged-provision.sh
+++ b/base/script/privileged-provision.sh
@@ -54,6 +54,7 @@ apt-get install -y unzip mtools
 wget https://s3.amazonaws.com/kubos-provisioning/iobc_toolchain.tar.gz
 tar -xf /home/vagrant/iobc_toolchain.tar.gz -C /usr/bin
 rm /home/vagrant/iobc_toolchain.tar.gz
+echo "export PATH=/usr/bin/iobc_toolchain/usr/bin:$PATH" >> /etc/profile
 
 #Beaglebone Black/Pumpkin MBM2 toolchain
 wget https://s3.amazonaws.com/kubos-provisioning/bbb_toolchain.tar.gz


### PR DESCRIPTION
This PR fixes two issues:

1. With the latest release, FTDI USB devices were being added as `/dev/ttyUSB*` belonging to the `plugdev` group, rather than the `dialout` group. This caused a permissions error when using `minicom kubos`
(This was caused by OpenOCD changing their udev rules file to be run later in the rules list. `40-openocd.rules` -> `60-openocd.rules`)
Fixed by manually assigning the devices to the `dialout` group.

2. Device tree binaries are built using one of U-Boot's tools, `dtc`. This application is included with our toolchains. Readding the iOBC toolchain to PATH so that `dtc` can be found and called during the build process. (It didn't actually matter which toolchain was added, since `dtc` runs on the local host)