### PR TITLE
Cross compiling fixes for Vagrant

### DIFF
--- a/kubos-dev/Vagrantfile
+++ b/kubos-dev/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "kubos/base"
-  config.vm.provision "file", source: "./bin/cargo_config", destination: "~/.cargo/config"
+  config.vm.provision "file", source: "./bin/cargo_config", destination: "~/cargo_config"
   config.vm.provision "privileged",    type: "shell", path: "./script/privileged-provision.sh"
   config.vm.provision "non-privileged", type: "shell", path: "./script/non-privileged-provision.sh", privileged: false
   config.vm.provision "test",          type: "shell", path: "./script/provision-test.sh"

--- a/kubos-dev/bin/cargo_config
+++ b/kubos-dev/bin/cargo_config
@@ -1,5 +1,5 @@
 [target.arm-unknown-linux-gnueabihf]
 linker = "/usr/bin/bbb_toolchain/usr/bin/arm-linux-gcc"
 
-[target.arm-unknown-linux-gnueabi]
+[target.armv5te-unknown-linux-gnueabi]
 linker = "/usr/bin/iobc_toolchain/usr/bin/arm-linux-gcc"

--- a/kubos-dev/script/non-privileged-provision.sh
+++ b/kubos-dev/script/non-privileged-provision.sh
@@ -1,17 +1,19 @@
 kubos update --latest || true #Can't run as root or else yotta symlinks are created to /root/.kubos/...
 
-#Install rust stuff
-#We do this as vagrant because it
-#installs to $HOME/
+# Install rust stuff
+# We do this as vagrant because it
+# installs to $HOME/
 # Rust toolchain + Cargo
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 echo 'export PATH=$PATH:"~/.cargo/bin"' >> /home/vagrant/.bashrc
 # bbb/mbm2 target
 /home/vagrant/.cargo/bin/rustup target install arm-unknown-linux-gnueabihf
 # iobc target
-/home/vagrant/.cargo/bin/rustup target install arm-unknown-linux-gnueabi
+/home/vagrant/.cargo/bin/rustup target install armv5te-unknown-linux-gnueabi
 # install cargo-kubos
-cd /home/vagrant/.kubos/kubos/cargo-kubos/ && /home/vagrant/.cargo/bin/cargo install
+/home/vagrant/.cargo/bin/cargo install --git https://github.com/kubos/cargo-kubos
+# setup cargo config
+mv /home/vagrant/cargo_config /home/vagrant/.cargo/config
 
 kubos update --tab-completion
 


### PR DESCRIPTION
- Correctly copy over cargo_config file
- Installs and configures correct toolchain for iobc