### PR TITLE
Moving iobc_toolchain to end of PATH

### DIFF
--- a/base/script/privileged-provision.sh
+++ b/base/script/privileged-provision.sh
@@ -54,7 +54,7 @@ apt-get install -y unzip mtools
 wget https://s3.amazonaws.com/kubos-provisioning/iobc_toolchain.tar.gz
 tar -xf /home/vagrant/iobc_toolchain.tar.gz -C /usr/bin
 rm /home/vagrant/iobc_toolchain.tar.gz
-echo "export PATH=/usr/bin/iobc_toolchain/usr/bin:$PATH" >> /etc/profile
+echo "export PATH=$PATH:/usr/bin/iobc_toolchain/usr/bin" >> /etc/profile
 
 #Beaglebone Black/Pumpkin MBM2 toolchain
 wget https://s3.amazonaws.com/kubos-provisioning/bbb_toolchain.tar.gz


### PR DESCRIPTION
`/usr/bin/iobc_toolchain/usr/bin` contains some libraries/executables which will be used by the host system since it's currently at the front of PATH for regular local actions. For example, `pkg-config`. However, having these files at this non-standard location causes problems for a bunch of dependencies which expect the libraries they use to live somewhere like `/usr/local/lib`.

Move the toolchain to the end of PATH so that the normal system locations get checked first.