### PR TITLE
Force downgrade pip to <v10

### DIFF
--- a/base/script/privileged-provision.sh
+++ b/base/script/privileged-provision.sh
@@ -30,7 +30,9 @@ mv /home/vagrant/libmsp430.so /usr/lib
 
 #do the pip setup and installation things
 easy_install pip
-pip install --upgrade pip
+# Need to install pip<v10 due to this issue: https://github.com/ARMmbed/yotta/issues/835
+# Forcibly controlling version until this is resolved
+pip install pip==9.0.3
 
 
 #documentation tools


### PR DESCRIPTION
There's a dependency incompatibility issue which causes the `RUN pip install -r https://raw.githubusercontent.com/kubos/kubos-cli/master/requirements.txt` command to fail: https://github.com/ARMmbed/yotta/issues/835
Forcing the pip install to remain at v9 until the issue is resolved

(This is the same fix as kubos/kubos#79)