### PR TITLE
Update S3 asset location

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For testing changes in the `kubos-dev` box only skip ahead to the "Testing kubos
 
 ## Testing Base Box Changes
 
-For testing the changes in the `base` box modify the Vagrantfile and provisioning scripts in the `base/` directory as needed. To test these changes in isolation from the `kubos-dev` box run:
+For testing the changes in the `base` box modify the Vagrantfile and provisioning scripts in the `base/` directory as needed. To test these changes in isolation from the `kubos-dev` box run (in the `base/` directory):
 
     $ vagrant up
 

--- a/base/script/privileged-provision.sh
+++ b/base/script/privileged-provision.sh
@@ -55,13 +55,13 @@ apt-get install -y libc6-i386 lib32stdc++6 lib32z1
 apt-get install -y unzip mtools
 
 #iOBC Toolchain
-wget https://s3.amazonaws.com/provisioning-kubos/iobc_toolchain.tar.gz
+wget https://s3.amazonaws.com/kubos-world-readable-assets/iobc_toolchain.tar.gz
 tar -xf /home/vagrant/iobc_toolchain.tar.gz -C /usr/bin
 rm /home/vagrant/iobc_toolchain.tar.gz
 echo "export PATH=$PATH:/usr/bin/iobc_toolchain/usr/bin" >> /etc/profile
 
 #Beaglebone Black/Pumpkin MBM2 toolchain
-wget https://s3.amazonaws.com/provisioning-kubos/bbb_toolchain.tar.gz
+wget https://s3.amazonaws.com/kubos-world-readable-assets/bbb_toolchain.tar.gz
 tar -xf /home/vagrant/bbb_toolchain.tar.gz -C /usr/bin
 rm /home/vagrant/bbb_toolchain.tar.gz
 


### PR DESCRIPTION
Update the location of the `*_toolchain.tar.gz` packages.

`vagrant up` finished in `base/` without obvious errors and the S3 assets appeared to download successfully from the new location.

Goes along with https://github.com/kubos/kubos/pull/156.