### PR TITLE
Adding explicit script failing. Manually installing resolvconf

### DIFF
--- a/builder/provision.py
+++ b/builder/provision.py
@@ -72,7 +72,7 @@ class BoxProvisioner(BoxAutomator):
 
     def dump_log(self):
         print('Dumping last {} lines of log: {}\n\n'.format(self.DUMP_LOG_LINES, self.step_log))
-        print(self.run_cmd('tail', '-n', '%i' % self.DUMP_LOG_LINES, self.step_log))
+        print(self.run_cmd('tail', '-n', '{}'.format(self.DUMP_LOG_LINES), self.step_log))
 
 
     def provision(self):

--- a/kubos-dev/script/non-privileged-provision.sh
+++ b/kubos-dev/script/non-privileged-provision.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -ex
+
 # Install rust stuff
 # We do this as vagrant because it
 # installs to $HOME/

--- a/kubos-dev/script/pre-package.sh
+++ b/kubos-dev/script/pre-package.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -x
+
 #Cleaning up before distribution
 #Clear out the cache
 rm -rf /var/cache/*

--- a/kubos-dev/script/privileged-provision.sh
+++ b/kubos-dev/script/privileged-provision.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -ex
+
 # These start an interactive prompt - I can't figure out how to fix it yet...
 sudo apt-mark hold grub-common grub-pc grub-pc-bin grub2-common
 
@@ -10,6 +13,11 @@ apt-get install -y build-essential ninja-build python-dev libffi-dev libssl-dev 
 apt-get install -y git
 apt-get install -y cmake
 apt-get install -y sshpass
+# resolvconf is no longer included by default as of Ubuntu 18.04
+apt-get install -y resolvconf
+rm -f /etc/resolv.conf
+# There's something wrong with the default resolv.conf symlink. This fixes it
+ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
 
 # Install kernel additions for better USB device recognition
 apt-get install -y linux-image-extra-virtual

--- a/kubos-dev/script/provision-test.sh
+++ b/kubos-dev/script/provision-test.sh
@@ -3,7 +3,7 @@
 #To add more programs to check for add them to the programs array.
 #Also runs standard CI tests to check if dev dependencies are installed and available
 
-set -e
+set -ex
 
 red='\E[31m'
 green='\E[32m'


### PR DESCRIPTION
Apparently Ubuntu 18.04 doesn't come with `resolvconf` installed, [which can lead to DNS problems](https://askubuntu.com/questions/1040304/dns-issues-with-virtualbox-vm-and-ubuntu-18-04)

I'm attempting a manual installation in order to fix it